### PR TITLE
Module to create service principals and/or managed identities/roles

### DIFF
--- a/terragrunt/identity_role.tf
+++ b/terragrunt/identity_role.tf
@@ -6,5 +6,4 @@ module "saas_app_service_principal" {
   location                 = var.region
   role_scope               = "/subscriptions/0bbd06bc-48ac-48bc-9275-c0cbeebef3b6"
   role_definition_name     = "Reader"
-  tenant_id                = var.tenant_id
 }

--- a/terragrunt/identity_role.tf
+++ b/terragrunt/identity_role.tf
@@ -1,0 +1,10 @@
+module "saas_app_service_principal" {
+  source                   = "./modules/identity_role"
+  name                     = "saas-app-service_principal"
+  create_service_principal = true
+  subscription_id          = "0bbd06bc-48ac-48bc-9275-c0cbeebef3b6" # Scratch subscription for testing
+  location                 = var.region
+  role_scope               = "/subscriptions/0bbd06bc-48ac-48bc-9275-c0cbeebef3b6"
+  role_definition_name     = "Reader"
+  tenant_id                = var.tenant_id
+}

--- a/terragrunt/modules/identity_role/examples/managed_identity_reader_role.tf
+++ b/terragrunt/modules/identity_role/examples/managed_identity_reader_role.tf
@@ -1,9 +1,10 @@
+# Example of how to use the identity_role module to create a managed identity and assign a Reader role to it.
 module "managed_identity" {
   source                  = "./terraform-modules/azure_identity_role"
   name                    = "my-mi"
   create_managed_identity = true
   resource_group_name     = "my-rg"
-  location                = "East US"
+  location                = "canadacentral"
   role_scope              = "/subscriptions/YOUR_SUBSCRIPTION_ID"
   role_definition_name    = "Reader"
 }

--- a/terragrunt/modules/identity_role/examples/managed_identity_reader_role.tf
+++ b/terragrunt/modules/identity_role/examples/managed_identity_reader_role.tf
@@ -1,0 +1,9 @@
+module "managed_identity" {
+  source                  = "./terraform-modules/azure_identity_role"
+  name                    = "my-mi"
+  create_managed_identity = true
+  resource_group_name     = "my-rg"
+  location                = "East US"
+  role_scope              = "/subscriptions/YOUR_SUBSCRIPTION_ID"
+  role_definition_name    = "Reader"
+}

--- a/terragrunt/modules/identity_role/examples/sp_contributor_role.tf
+++ b/terragrunt/modules/identity_role/examples/sp_contributor_role.tf
@@ -1,0 +1,7 @@
+module "service_principal" {
+  source                   = "./terraform-modules/azure_identity_role"
+  name                     = "my-sp"
+  create_service_principal = true
+  role_scope               = "/subscriptions/YOUR_SUBSCRIPTION_ID"
+  role_definition_name     = "Contributor"
+}

--- a/terragrunt/modules/identity_role/examples/sp_contributor_role.tf
+++ b/terragrunt/modules/identity_role/examples/sp_contributor_role.tf
@@ -1,3 +1,4 @@
+# Example of how to create a service principal and assign it the "Contributor" role at the subscription level
 module "service_principal" {
   source                   = "./terraform-modules/azure_identity_role"
   name                     = "my-sp"

--- a/terragrunt/modules/identity_role/examples/sp_custom_role.tf
+++ b/terragrunt/modules/identity_role/examples/sp_custom_role.tf
@@ -1,0 +1,9 @@
+module "service_principal_custom_role" {
+  source                   = "./terraform-modules/azure_identity_role"
+  name                     = "custom-sp"
+  create_service_principal = true
+  role_scope               = "/subscriptions/YOUR_SUBSCRIPTION_ID"
+  create_custom_role       = true
+  role_name                = "CustomReadOnly"
+  role_permissions         = ["Microsoft.Resources/subscriptions/resourceGroups/read"]
+}

--- a/terragrunt/modules/identity_role/examples/sp_custom_role.tf
+++ b/terragrunt/modules/identity_role/examples/sp_custom_role.tf
@@ -1,3 +1,6 @@
+# This is an example of how to use the service_principal_custom_role module to create a custom role and assign it to a service principal.
+# This example creates a custom role named "CustomReadOnly" with the permission to read resource groups.
+# The service principal is created and assigned the custom role at the subscription level.
 module "service_principal_custom_role" {
   source                   = "./terraform-modules/azure_identity_role"
   name                     = "custom-sp"

--- a/terragrunt/modules/identity_role/main.tf
+++ b/terragrunt/modules/identity_role/main.tf
@@ -1,0 +1,72 @@
+
+locals {
+  tenant_id = coalesce(var.tenant_id, data.azurerm_client_config.current.tenant_id)
+}
+
+#========== PROVIDERS ==========
+provider "azurerm" {
+  skip_provider_registration = true
+  subscription_id            = var.subscription_id
+  features {}
+}
+provider "azuread" {
+  tenant_id = local.tenant_id
+}
+
+# Get the current client configuration from the AzureRM provider.
+
+data "azurerm_client_config" "current" {}
+
+# ========== CONDITIONAL SERVICE PRINCIPAL CREATION ==========
+resource "azuread_application" "sp_app" {
+  count        = var.create_service_principal ? 1 : 0
+  display_name = var.name
+}
+
+resource "azuread_service_principal" "sp" {
+  count     = var.create_service_principal ? 1 : 0
+  client_id = azuread_application.sp_app[0].client_id
+}
+
+resource "azuread_service_principal_password" "sp_password" {
+  count                = var.create_service_principal ? 1 : 0
+  service_principal_id = azuread_service_principal.sp[0].id
+}
+
+# ========== CONDITIONAL MANAGED IDENTITY CREATION ==========
+resource "azurerm_user_assigned_identity" "managed_identity" {
+  count               = var.create_managed_identity ? 1 : 0
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+}
+
+# ========== CONDITIONAL ROLE CREATION ==========
+resource "azurerm_role_definition" "custom_role" {
+  count       = var.create_custom_role ? 1 : 0
+  name        = var.role_name
+  scope       = var.role_scope
+  description = "Custom role for ${var.name}"
+
+  permissions {
+    actions     = var.role_permissions
+    not_actions = []
+  }
+
+  assignable_scopes = [var.role_scope]
+}
+
+# ========== ROLE ASSIGNMENT TO IDENTITY ==========
+resource "azurerm_role_assignment" "role_assignment_sp" {
+  count                = var.create_service_principal ? 1 : 0
+  scope                = var.role_scope
+  role_definition_name = var.create_custom_role ? azurerm_role_definition.custom_role[0].name : var.role_definition_name
+  principal_id         = azuread_service_principal.sp[0].object_id
+}
+
+resource "azurerm_role_assignment" "role_assignment_mi" {
+  count                = var.create_managed_identity ? 1 : 0
+  scope                = var.role_scope
+  role_definition_name = var.create_custom_role ? azurerm_role_definition.custom_role[0].name : var.role_definition_name
+  principal_id         = azurerm_user_assigned_identity.managed_identity[0].principal_id
+}

--- a/terragrunt/modules/identity_role/main.tf
+++ b/terragrunt/modules/identity_role/main.tf
@@ -1,4 +1,44 @@
 
+# This Terraform module is used to manage Azure identities and roles.
+# It includes conditional creation of service principals, managed identities,
+# custom roles, and role assignments based on the provided variables.
+
+# Local Variables:
+# - tenant_id: The tenant ID to use, either from the provided variable or the current AzureRM client configuration.
+
+# Providers:
+# - azurerm: Configured with the subscription ID and features.
+# - azuread: Configured with the tenant ID.
+
+# Data Sources:
+# - azurerm_client_config: Retrieves the current client configuration from the AzureRM provider.
+
+# Resources:
+# - azuread_application.sp_app: Conditionally creates an Azure AD application for the service principal.
+# - azuread_service_principal.sp: Conditionally creates a service principal for the Azure AD application.
+# - azuread_service_principal_password.sp_password: Conditionally creates a password for the service principal.
+# - azurerm_user_assigned_identity.managed_identity: Conditionally creates a user-assigned managed identity.
+# - azurerm_role_definition.custom_role: Conditionally creates a custom role definition.
+# - azurerm_role_assignment.role_assignment_sp: Conditionally assigns a role to the service principal.
+# - azurerm_role_assignment.role_assignment_mi: Conditionally assigns a role to the managed identity.
+
+# Variables:
+# - tenant_id: The tenant ID to use (optional).
+# - subscription_id: The subscription ID to use.
+# - create_service_principal: Boolean to determine if a service principal should be created.
+# - create_managed_identity: Boolean to determine if a managed identity should be created.
+# - create_custom_role: Boolean to determine if a custom role should be created.
+# - name: The name to use for the service principal or managed identity.
+# - resource_group_name: The resource group name for the managed identity.
+# - location: The location for the managed identity.
+# - role_name: The name of the custom role.
+# - role_scope: The scope for the custom role and role assignments.
+# - role_permissions: The permissions for the custom role.
+# - role_definition_name: The name of the role definition to assign if not creating a custom role.
+
+
+# Define a local value `tenant_id` which is set to the value of the `tenant_id` variable if it is provided.
+# If the `tenant_id` variable is not provided, it defaults to the tenant ID of the current Azure client configuration.
 locals {
   tenant_id = coalesce(var.tenant_id, data.azurerm_client_config.current.tenant_id)
 }

--- a/terragrunt/modules/identity_role/outputs.tf
+++ b/terragrunt/modules/identity_role/outputs.tf
@@ -1,0 +1,26 @@
+output "service_principal_id" {
+  description = "The object ID of the created Service Principal (if applicable)"
+  value       = var.create_service_principal ? azuread_service_principal.sp[0].id : null
+}
+
+output "service_principal_client_id" {
+  description = "The client ID of the created Service Principal (if applicable)"
+  value       = var.create_service_principal ? azuread_application.sp_app[0].client_id : null
+}
+
+output "managed_identity_id" {
+  description = "The principal ID of the created Managed Identity (if applicable)"
+  value       = var.create_managed_identity ? azurerm_user_assigned_identity.managed_identity[0].principal_id : null
+}
+
+output "role_assignment_id" {
+  description = "The ID of the role assignment"
+  value       = var.create_service_principal ? azurerm_role_assignment.role_assignment_sp[0].id : azurerm_role_assignment.role_assignment_mi[0].id
+  sensitive   = true
+}
+
+output "service_principal_password" {
+  description = "The password of the created Service Principal (if applicable)"
+  value       = var.create_service_principal ? azuread_service_principal_password.sp_password[0].value : null
+  sensitive   = true
+}

--- a/terragrunt/modules/identity_role/variables.tf
+++ b/terragrunt/modules/identity_role/variables.tf
@@ -1,0 +1,66 @@
+variable "name" {
+  description = "The name of the identity"
+  type        = string
+}
+
+variable "location" {
+  description = "The Azure region"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group (only required for Managed Identity)"
+  type        = string
+  default     = null
+}
+
+variable "create_service_principal" {
+  description = "Set to true to create a Service Principal"
+  type        = bool
+  default     = false
+}
+
+variable "create_managed_identity" {
+  description = "Set to true to create a Managed Identity"
+  type        = bool
+  default     = false
+}
+
+variable "role_scope" {
+  description = "The scope where the role assignment should be applied"
+  type        = string
+}
+
+variable "create_custom_role" {
+  description = "Set to true to create a custom role"
+  type        = bool
+  default     = false
+}
+
+variable "role_name" {
+  description = "The name of the role to assign"
+  type        = string
+  default     = "Contributor"
+}
+
+variable "role_definition_name" {
+  description = "The existing role name to assign (ignored if create_custom_role is true)"
+  type        = string
+  default     = "Reader"
+}
+
+variable "role_permissions" {
+  description = "The permissions to be assigned in a custom role"
+  type        = list(string)
+  default     = ["Microsoft.Resources/subscriptions/resourceGroups/read"]
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "The subscription ID to create resources in."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "The tenant ID to create resources in."
+}

--- a/terragrunt/modules/identity_role/variables.tf
+++ b/terragrunt/modules/identity_role/variables.tf
@@ -63,4 +63,5 @@ variable "subscription_id" {
 variable "tenant_id" {
   type        = string
   description = "The tenant ID to create resources in."
+  default     = null
 }


### PR DESCRIPTION
# Summary | Résumé

Terraform module to use in Azure to create Service principal or managed identities and assign a role to them. You can also create a custom role to assign to them as well. 

Next we can import all the existing resources - fun, fun!