### PR TITLE
Fix to correctly create the storage container

### DIFF
--- a/terragrunt/common/providers.tf
+++ b/terragrunt/common/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.107"
+      version = "~> 4.23.0"
     }
     azapi = {
       source  = "Azure/azapi"

--- a/terragrunt/modules/cost_exports/main.tf
+++ b/terragrunt/modules/cost_exports/main.tf
@@ -25,8 +25,8 @@ resource "azurerm_storage_account" "cost_exports_storage" {
 }
 
 resource "azurerm_storage_container" "cost_exports_container" {
-  name                 = "cost-exports-container"
-  storage_account_name = azurerm_storage_account.cost_exports_storage.name
+  name               = "cost-exports-container"
+  storage_account_id = azurerm_storage_account.cost_exports_storage.id
 }
 
 

--- a/terragrunt/modules/cost_exports/main.tf
+++ b/terragrunt/modules/cost_exports/main.tf
@@ -44,7 +44,7 @@ resource "azurerm_billing_account_cost_management_export" "this" {
   }
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.cost_exports_container.id
+    container_id     = azurerm_storage_container.cost_exports_container.resource_manager_id
     root_folder_path = "${var.root_folder_path}-${var.name}"
   }
 }

--- a/terragrunt/modules/openai_api_key/main.tf
+++ b/terragrunt/modules/openai_api_key/main.tf
@@ -56,8 +56,8 @@ resource "azurerm_cognitive_deployment" "deployment" {
     version = each.value.model.version
   }
 
-  scale {
-    type     = "GlobalStandard"
+  sku {
+    name     = "GlobalStandard"
     capacity = 50 # Represents 50,000 TPM
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Fix the storage_container resource since storage_account_name is deprecated and we should be using the storage_account_id (plus it was originally not referenced correctly). 

I also updated the azurem provider to be the latest version. 