### PR TITLE
Additional AI models for DTO plus fixing account id

### DIFF
--- a/terragrunt/modules/cost_exports/variables.tf
+++ b/terragrunt/modules/cost_exports/variables.tf
@@ -18,7 +18,7 @@ variable "primary_location" {
 variable "billing_account_id" {
   type        = string
   description = "(Required) The id of the billing account on which to create an export. Changing this forces a new resource to be created."
-  default     = "7039692"
+  default     = "/providers/Microsoft.Billing/billingAccounts/7039692"
 }
 
 variable "recurrence_type" {

--- a/terragrunt/openai_api_keys.tf
+++ b/terragrunt/openai_api_keys.tf
@@ -15,4 +15,32 @@ module "ai_answers_api_key" {
   resource_group_name_prefix = "ai-answers"
   budget_amount              = 50
   requestor_emails           = ["HamzaBelal.Aburaneh@cds-snc.ca"]
+
+  # Create additional deployments for AI answers. Deployments include gpt-40, text-embedding-3-small and the default gpt-4o-mini
+  openai_deployments = [{
+    name = "gpt-4o"
+    model = {
+      name    = "gpt-4o"
+      version = "2024-11-20"
+    }
+    rai_policy_name = ""
+    },
+    {
+      name = "text-embedding-3-large"
+      model = {
+        name    = "text=embedding-3-large"
+        version = "1"
+      }
+      rai_policy_name = ""
+
+    },
+    {
+      name = "openai-gpt4o-mini"
+      model = {
+        name    = "gpt-4o-mini"
+        version = "2024-07-18"
+      }
+      rai_policy_name = ""
+    }
+  ]
 }


### PR DESCRIPTION
# Summary | Résumé

DTO has requested that 2 additional models/deployments are added to their subscription and this PR deploys those. Additionally, a change is made where the billing account id is properly referenced in the costing export because the terraform apply failed due to that. 