### PR TITLE
Remvoing text-embedding model as it is not supported in our instance

### DIFF
--- a/terragrunt/openai_api_keys.tf
+++ b/terragrunt/openai_api_keys.tf
@@ -26,15 +26,6 @@ module "ai_answers_api_key" {
     rai_policy_name = ""
     },
     {
-      name = "text-embedding-3-large"
-      model = {
-        name    = "text=embedding-3-large"
-        version = "1"
-      }
-      rai_policy_name = ""
-
-    },
-    {
       name = "openai-gpt4o-mini"
       model = {
         name    = "gpt-4o-mini"


### PR DESCRIPTION
# Summary | Résumé

The apply failed and after further investigation this model is not available for us to use. It is available in our region but if you try to create a deployment, this model is just not listed as an option. As a result, it seems that this is not something that we can use right now. 
