### PR TITLE
Adding conditional access policies

### DIFF
--- a/terragrunt/conditional_access.tf
+++ b/terragrunt/conditional_access.tf
@@ -1,0 +1,91 @@
+# Create the named locations and conditional access policies in the Azure AD tenant
+
+# Create named locations for US, Canada and ESDC Ips
+resource "azuread_named_location" "canada" {
+  display_name = "Canada"
+  country {
+    countries_and_regions = [
+      "CA",
+    ]
+    include_unknown_countries_and_regions = false
+  }
+}
+
+resource "azuread_named_location" "united_states" {
+  display_name = "United States"
+  country {
+    countries_and_regions = [
+      "US",
+    ]
+    include_unknown_countries_and_regions = false
+  }
+}
+
+resource "azuread_named_location" "esdc_ips" {
+  display_name = "ESDC IPs"
+  ip {
+    ip_ranges = [
+      "198.103.0.0/16",
+    ]
+    trusted = true
+  }
+}
+
+# Conditional access policy to block non-browser access
+module "block_non_browser" {
+  source                = "./modules/conditional_access"
+  policy_name           = "Conditional Access - Block Non-Browser Access"
+  client_app_types      = ["exchangeActiveSync", "mobileAppsAndDesktopClients", "other"]
+  included_applications = ["All"]
+  excluded_applications = ["797f4846-ba00-4fd7-ba43-dac1f8f63013"] # this is the resource id of Azure CLI, application ID doesn't work
+  included_locations    = ["All"]
+  included_platforms    = ["all"]
+  included_users        = ["All"]
+  excluded_groups       = ["86a827be-9f2d-46fe-992e-9445ec10e840", "9c8babe3-fe86-42b1-ace6-16734f559c60", "dda4f58f-e024-40da-9403-761270c5cc47"]
+  built_in_controls     = ["block"]
+  operator              = "OR"
+}
+
+# Conditional access policy to block access from outside of Canada
+module "block_out_of_canada" {
+  source                = "./modules/conditional_access"
+  policy_name           = "Conditional Access - Block Out of Canada"
+  client_app_types      = ["all"]
+  included_applications = ["All"]
+  included_locations    = ["All"]
+  excluded_locations    = [resource.azuread_named_location.united_states.id, resource.azuread_named_location.canada.id]
+  included_platforms    = ["all"]
+  included_users        = ["All"]
+  excluded_groups       = ["86a827be-9f2d-46fe-992e-9445ec10e840"]
+  built_in_controls     = ["block"]
+  operator              = "OR"
+}
+
+# Conditional access policy to block non-MacOS systems
+module "block_non_macos" {
+  source                = "./modules/conditional_access"
+  policy_name           = "Conditional Access - Block Non-MacOS Systems"
+  client_app_types      = ["all"]
+  included_applications = ["All"]
+  included_locations    = ["All"]
+  excluded_locations    = [resource.azuread_named_location.esdc_ips.id]
+  included_platforms    = ["all"]
+  excluded_platforms    = ["macOS", "linux"]
+  included_users        = ["All"]
+  excluded_groups       = ["86a827be-9f2d-46fe-992e-9445ec10e840"]
+  built_in_controls     = ["block"]
+  operator              = "OR"
+}
+
+# Conditional access policy to block TC users portal access
+module "block_tc_user_portal_access" {
+  source                = "./modules/conditional_access"
+  policy_name           = "Conditional Access - Block TC Users Portal Access"
+  client_app_types      = ["all"]
+  included_applications = ["797f4846-ba00-4fd7-ba43-dac1f8f63013"]
+  included_locations    = ["All"]
+  included_platforms    = ["all"]
+  included_groups       = ["f587d598-8c31-4889-b8a7-e059c253ae84"]
+  built_in_controls     = ["block"]
+  operator              = "OR"
+}

--- a/terragrunt/modules/conditional_access/main.tf
+++ b/terragrunt/modules/conditional_access/main.tf
@@ -1,0 +1,36 @@
+# Terraform module to create Conditional Access policies in Azure AD
+
+# Conditional Access policies
+resource "azuread_conditional_access_policy" "this" {
+  display_name = var.policy_name
+  state        = "enabled"
+
+  conditions {
+    client_app_types = var.client_app_types
+
+    applications {
+      included_applications = var.included_applications
+      excluded_applications = var.excluded_applications
+    }
+
+    locations {
+      included_locations = var.included_locations
+      excluded_locations = var.excluded_locations
+    }
+
+    platforms {
+      included_platforms = var.included_platforms
+      excluded_platforms = var.excluded_platforms
+    }
+
+    users {
+      included_users  = var.included_users
+      excluded_groups = var.excluded_groups
+    }
+  }
+
+  grant_controls {
+    built_in_controls = var.built_in_controls
+    operator          = var.operator
+  }
+}

--- a/terragrunt/modules/conditional_access/outputs.tf
+++ b/terragrunt/modules/conditional_access/outputs.tf
@@ -1,0 +1,4 @@
+output "policy_id" {
+  value       = azuread_conditional_access_policy.this.id
+  description = "ID of the created Conditional Access Policy"
+}

--- a/terragrunt/modules/conditional_access/variables.tf
+++ b/terragrunt/modules/conditional_access/variables.tf
@@ -1,0 +1,71 @@
+# Conditional Access Policies variables
+variable "policy_name" {
+  description = "Name of the conditional access policy"
+  type        = string
+}
+
+variable "client_app_types" {
+  description = "List of client app types"
+  type        = list(string)
+}
+
+variable "included_applications" {
+  description = "List of included applications"
+  type        = list(string)
+}
+
+variable "excluded_applications" {
+  description = "List of excluded applications"
+  type        = list(string)
+  default     = []
+}
+
+variable "included_locations" {
+  description = "List of included locations"
+  type        = list(string)
+}
+
+variable "excluded_locations" {
+  description = "List of excluded locations"
+  type        = list(string)
+  default     = []
+}
+
+variable "included_platforms" {
+  description = "List of included platforms"
+  type        = list(string)
+}
+
+variable "excluded_platforms" {
+  description = "List of excluded platforms"
+  type        = list(string)
+  default     = []
+}
+
+variable "included_users" {
+  description = "List of included users"
+  type        = list(string)
+  default     = []
+}
+
+variable "included_groups" {
+  description = "List of included groups"
+  type        = list(string)
+  default     = []
+}
+
+variable "excluded_groups" {
+  description = "List of excluded groups"
+  type        = list(string)
+  default     = []
+}
+
+variable "built_in_controls" {
+  description = "List of built-in controls"
+  type        = list(string)
+}
+
+variable "operator" {
+  description = "Operator for grant controls"
+  type        = string
+}


### PR DESCRIPTION
# Summary | Résumé

Conditional access polices - thought that we had done this already in here but it does not seem so. This creates the conditional access policies in Terraform and we can later remove them from the Sentinel repo once we know they are working. 
