### PR TITLE
Increasing TPM for AI answers plus adding extra variables

### DIFF
--- a/terragrunt/modules/openai_api_key/main.tf
+++ b/terragrunt/modules/openai_api_key/main.tf
@@ -58,7 +58,8 @@ resource "azurerm_cognitive_deployment" "deployment" {
 
   sku {
     name     = "GlobalStandard"
-    capacity = 50 # Represents 50,000 TPM
+    capacity = coalesce(try(each.value.sku.capacity, null), 50)
+    # each.value.sku.capacity #coalesce(each.value.sku.capacity, 50) # If the capacity value is not set, then 50,000 TPM will be automatically set
   }
 }
 
@@ -71,8 +72,8 @@ resource "azurerm_consumption_budget_resource_group" "openai_budget" {
 
   # Let the budget alarm expire in 10 years. We basically want to send the budget alarm to the user for indeterminate, which is currently max 10 years in the settings.
   time_period {
-    start_date = "2025-02-01T00:00:00Z"
-    end_date   = "2035-02-01T00:00:00Z"
+    start_date = var.budget_start_date
+    end_date   = var.budget_end_date #try(var.end_date, null)  #var.end_date)
   }
   notification {
     enabled        = true

--- a/terragrunt/modules/openai_api_key/main.tf
+++ b/terragrunt/modules/openai_api_key/main.tf
@@ -59,7 +59,6 @@ resource "azurerm_cognitive_deployment" "deployment" {
   sku {
     name     = "GlobalStandard"
     capacity = coalesce(try(each.value.sku.capacity, null), 50)
-    # each.value.sku.capacity #coalesce(each.value.sku.capacity, 50) # If the capacity value is not set, then 50,000 TPM will be automatically set
   }
 }
 

--- a/terragrunt/modules/openai_api_key/main.tf
+++ b/terragrunt/modules/openai_api_key/main.tf
@@ -73,7 +73,7 @@ resource "azurerm_consumption_budget_resource_group" "openai_budget" {
   # Let the budget alarm expire in 10 years. We basically want to send the budget alarm to the user for indeterminate, which is currently max 10 years in the settings.
   time_period {
     start_date = var.budget_start_date
-    end_date   = var.budget_end_date #try(var.end_date, null)  #var.end_date)
+    end_date   = var.budget_end_date 
   }
   notification {
     enabled        = true

--- a/terragrunt/modules/openai_api_key/variables.tf
+++ b/terragrunt/modules/openai_api_key/variables.tf
@@ -30,7 +30,6 @@ variable "subscription_id" {
   type        = string
   description = "The subscription ID to create the Azure Cognitive Services account."
 }
-
 variable "openai_deployments" {
   description = "(Optional) Specifies the deployments of the Azure OpenAI Service"
   type = list(object({
@@ -39,6 +38,9 @@ variable "openai_deployments" {
       name    = string
       version = string
     })
+    sku = optional(object({
+      capacity = optional(number)
+    }))
     rai_policy_name = string
   }))
   default = [
@@ -47,6 +49,9 @@ variable "openai_deployments" {
       model = {
         name    = "gpt-4o-mini"
         version = "2024-07-18"
+      }
+      sku = {
+        capacity = 50
       }
       rai_policy_name = ""
     }
@@ -63,6 +68,18 @@ variable "budget_time_grain" {
   type        = string
   description = "The time period for the budget. The default is Monthly."
   default     = "Monthly"
+}
+
+variable "budget_start_date" {
+  description = "Start date for the budget alarm (YYYY-MM-DDTHH:MM:SSZ)"
+  type        = string
+  default     = "2025-02-01T00:00:00Z" # Or set to the first of the current month
+}
+
+variable "budget_end_date" {
+  description = "End date for the budget alarm (YYYY-MM-DDTHH:MM:SSZ)"
+  type  = string
+  default = "2035-02-01T00:00:00Z"
 }
 
 variable "requestor_emails" {

--- a/terragrunt/openai_api_keys.tf
+++ b/terragrunt/openai_api_keys.tf
@@ -23,6 +23,9 @@ module "ai_answers_api_key" {
       name    = "gpt-4o"
       version = "2024-11-20"
     }
+    sku = {
+      capacity = 200
+    }
     rai_policy_name = ""
     },
     {
@@ -30,6 +33,9 @@ module "ai_answers_api_key" {
       model = {
         name    = "gpt-4o-mini"
         version = "2024-07-18"
+      }
+      sku = {
+        capacity = 200
       }
       rai_policy_name = ""
     },
@@ -39,6 +45,10 @@ module "ai_answers_api_key" {
         name    = "text-embedding-3-large"
         version = "1"
       }
+      sku = {
+        capacity = 200
+      }
+
       rai_policy_name = ""
     }
   ]
@@ -47,9 +57,10 @@ module "ai_answers_api_key" {
 module "platform_core_hackathon_api_key" {
   source                     = "./modules/openai_api_key"
   subscription_id            = "c4122b45-f2e3-4873-a7fe-b94c1ad2589f" # CDS-AI subscription
-  name                       = "platform_core_hackathon"
-  custom_subdomain_name      = "platform_core_hackathon"
-  resource_group_name_prefix = "platform_core_hackathon"
+  name                       = "platform-core-hackathon"
+  custom_subdomain_name      = "platform-core-hackathon"
+  resource_group_name_prefix = "platform-core-hackathon"
+  budget_start_date          = "2025-05-01T00:00:00Z"
   budget_amount              = 50
   requestor_emails           = ["platform-core-services@cds-snc.ca"]
 


### PR DESCRIPTION
# Summary | Résumé

Changes made with this PR:
1. Increased TPM for ai-answers to 200 TPM. 
2. changed the name, group prefix and subdomain name to contain - instead of _
3. Made the start and end date as variables since when creating budget alarms, the start date can't be earlier than the current month. 