### PR TITLE
Add custom Azure AD role module

### DIFF
--- a/terragrunt/common/providers.tf
+++ b/terragrunt/common/providers.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "Azure/azapi"
       version = ">= 1.13.1"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.4.0"
+    }
   }
 }
 

--- a/terragrunt/custom_entraid_roles.tf
+++ b/terragrunt/custom_entraid_roles.tf
@@ -1,0 +1,23 @@
+# Define a custom role for creating unlimited application registrations in Azure AD
+module "custom_entraid_roles_appreg" {
+  source       = "./modules/custom_entraid_roles"
+  display_name = "Application Registration Creator"
+  description  = "Can create an unlimited number of application registrations"
+  permissions = [
+    "microsoft.directory/applications/create",
+    "microsoft.directory/applications/createAsOwner"
+  ]
+  role_version = "1.0"
+  enabled      = true
+}
+
+# Assign the custom role to the group 'DC Admins'
+data "azuread_group" "dc_admins" {
+  display_name = "DC Admins"
+}
+
+resource "azuread_directory_role_assignment" "appreg_creator_to_dc_admins" {
+  role_id             = module.custom_entraid_roles_appreg.id
+  principal_object_id = data.azuread_group.dc_admins.object_id
+}
+

--- a/terragrunt/modules/custom_entraid_roles/README.md
+++ b/terragrunt/modules/custom_entraid_roles/README.md
@@ -1,0 +1,30 @@
+# custom_entraid_roles Terraform Module
+
+This module provisions an Azure AD custom directory role using the `azuread_custom_directory_role` resource.
+
+## Usage
+
+```hcl
+module "custom_entraid_roles" {
+  source       = "./modules/custom_entraid_roles"
+  display_name = "My Custom Role"
+  description  = "Custom role for special permissions."
+  permissions  = [
+    "microsoft.directory/applications/allProperties/read",
+    # Add more permissions as needed
+  ]
+  enabled      = true         # Optional, default: true
+  version      = "1.0"        # Optional, default: "1.0"
+}
+```
+
+## Inputs
+- `display_name` (string, required): The display name for the custom directory role.
+- `description` (string, optional): The description for the custom directory role.
+- `permissions` (set(string), required): A set of permission values to assign to the role.
+- `enabled` (bool, optional): Whether the custom directory role is enabled. Default is `true`.
+- `version` (string, optional): The version of the custom directory role. Default is `"1.0"`.
+
+## Outputs
+- `id`: The ID of the custom directory role.
+- `display_name`: The display name of the custom directory role.

--- a/terragrunt/modules/custom_entraid_roles/main.tf
+++ b/terragrunt/modules/custom_entraid_roles/main.tf
@@ -1,0 +1,14 @@
+provider "azuread" {
+  tenant_id = var.tenant_id
+}
+
+resource "azuread_custom_directory_role" "this" {
+  display_name = var.display_name
+  description  = var.description
+  enabled      = var.enabled
+  version      = var.role_version
+
+  permissions {
+    allowed_resource_actions = var.permissions
+  }
+}

--- a/terragrunt/modules/custom_entraid_roles/outputs.tf
+++ b/terragrunt/modules/custom_entraid_roles/outputs.tf
@@ -1,0 +1,9 @@
+output "id" {
+  description = "The ID of the custom directory role."
+  value       = azuread_custom_directory_role.this.id
+}
+
+output "display_name" {
+  description = "The display name of the custom directory role."
+  value       = azuread_custom_directory_role.this.display_name
+}

--- a/terragrunt/modules/custom_entraid_roles/variables.tf
+++ b/terragrunt/modules/custom_entraid_roles/variables.tf
@@ -1,0 +1,32 @@
+variable "display_name" {
+  description = "The display name for the custom directory role."
+  type        = string
+}
+
+variable "description" {
+  description = "The description for the custom directory role."
+  type        = string
+  default     = null
+}
+
+variable "permissions" {
+  description = "A set of permission values to assign to the role."
+  type        = set(string)
+}
+
+variable "enabled" {
+  description = "Whether the custom directory role is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "role_version" {
+  description = "The version of the custom directory role."
+  type        = string
+  default     = "1.0"
+}
+variable "tenant_id" {
+  type        = string
+  description = "The tenant ID to create resources in."
+  default     = null
+}


### PR DESCRIPTION
# Summary | Résumé

This PR adds a custom EntraID role and assigned the role to 'DC Admins' group so they can created unlimited EntraID resources.