### PR TITLE
double quote instead of single quote

### DIFF
--- a/terragrunt/scheduled_query_alert_rules.tf
+++ b/terragrunt/scheduled_query_alert_rules.tf
@@ -82,7 +82,7 @@ module "breakglass_account_signin_attempt" {
   operator                = "GreaterThan"
   time_aggregation_method = "Count"
   threshold               = 0
-  query                   = "SigninLogs | where UserPrincipalName in ('ops1@cdssnc.onmicrosoft.com','ops2@cdssnc.onmicrosoft.com')"
+  query                   = "SigninLogs | where UserPrincipalName in (\"ops1@cdssnc.onmicrosoft.com\",\"ops2@cdssnc.onmicrosoft.com\")"
 
   enabled = true
 


### PR DESCRIPTION
# Summary | Résumé

this PR uses double quotes in the query to satisfy the CaC check