### PR TITLE
Add security email to action group

### DIFF
--- a/terragrunt/scheduled_query_alert_rules.tf
+++ b/terragrunt/scheduled_query_alert_rules.tf
@@ -41,6 +41,11 @@ resource "azurerm_monitor_action_group" "SRE_GR_AG" {
     name                    = "Internal SRE_-EmailAction-"
     use_common_alert_schema = false
   }
+  email_receiver {
+    email_address           = var.security_email
+    name                    = "Internal Security_-EmailAction-"
+    use_common_alert_schema = false
+  }
 }
 
 module "conditional_access_policy_modification" {


### PR DESCRIPTION
Include a new email receiver in the action group for security notifications.

fixes https://github.com/cds-snc/azure-guardrails-solution-accelerator/issues/18