### PR TITLE
add GCIV-Consultants to the exception of non-Mac CAP. and add the missing MFA CAP

### DIFF
--- a/terragrunt/conditional_access_policies.tf
+++ b/terragrunt/conditional_access_policies.tf
@@ -94,7 +94,7 @@ module "block_non_macos" {
   included_platforms = ["all"]
 
   included_users  = ["All"]
-  excluded_groups = ["86a827be-9f2d-46fe-992e-9445ec10e840", "bec61a23-7411-4854-af2e-ecc7391f5b90"]
+  excluded_groups = ["86a827be-9f2d-46fe-992e-9445ec10e840", "bec61a23-7411-4854-af2e-ecc7391f5b90", "0d95296d-9231-4eff-b32b-6fc3ce861fe1"]
 
   built_in_controls = ["block"]
   operator          = "OR"
@@ -181,4 +181,21 @@ module "password_change_high_user_risk" {
 
   built_in_controls = ["mfa", "passwordChange"]
   operator          = "AND"
+}
+
+module "mfa" {
+  source = "./modules/conditional_access"
+
+  policy_name = "MFA"
+  state       = "enabled"
+
+  client_app_types = ["all"]
+
+  included_applications = ["All"]
+
+  included_users  = ["All"]
+  excluded_groups = ["86a827be-9f2d-46fe-992e-9445ec10e840"]
+
+  built_in_controls = ["mfa"]
+  operator          = "OR"
 }

--- a/terragrunt/custom_entraid_roles.tf
+++ b/terragrunt/custom_entraid_roles.tf
@@ -11,9 +11,9 @@ module "custom_entraid_roles_appreg" {
   enabled      = true
 }
 
-# Assign the custom role to the group 'DC Admins'
+# Assign the custom role to the group 'GCIV Admins'
 data "azuread_group" "dc_admins" {
-  display_name = "DC Admins"
+  display_name = "GCIV Admins"
 }
 
 resource "azuread_directory_role_assignment" "appreg_creator_to_dc_admins" {

--- a/terragrunt/custom_entraid_roles.tf
+++ b/terragrunt/custom_entraid_roles.tf
@@ -13,7 +13,7 @@ module "custom_entraid_roles_appreg" {
 
 # Assign the custom role to the group 'GCIV Admins'
 data "azuread_group" "dc_admins" {
-  display_name = "GCIV Admins"
+  object_id = "dda4f58f-e024-40da-9403-761270c5cc47"
 }
 
 resource "azuread_directory_role_assignment" "appreg_creator_to_dc_admins" {


### PR DESCRIPTION
This PR adds the GCIV-Consultants group to the exception list of Block Non-Mac CAP. and also add the missing MFA CAP terraform code.