### PR TITLE
refactor the open_api_keys module

### DIFF
--- a/terragrunt/common/providers.tf
+++ b/terragrunt/common/providers.tf
@@ -18,3 +18,22 @@ terraform {
 provider "azapi" {
   use_msi = false
 }
+
+# Aliased providers for OpenAI module instances that target subscriptions
+# other than the default (CDS-SNC-Management) provider defined in
+# scheduled_query_alert_rules.tf.
+
+provider "azurerm" {
+  alias                           = "sre_tools"
+  subscription_id                 = "204b7832-86f3-4792-8e35-860862258324"
+  resource_provider_registrations = "none"
+  features {}
+}
+
+provider "azurerm" {
+  alias                           = "dto"
+  subscription_id                 = "5617b0eb-50cc-4fe6-b57e-021e6ec245f0"
+  resource_provider_registrations = "none"
+  features {}
+}
+

--- a/terragrunt/modules/openai_api_key/main.tf
+++ b/terragrunt/modules/openai_api_key/main.tf
@@ -1,9 +1,14 @@
-# Define the provider configuration
-
-provider "azurerm" {
-  resource_provider_registrations = "none"
-  features {}
-  subscription_id = var.subscription_id
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.38.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
 }
 
 # Get the current client configuration from the AzureRM provider.
@@ -16,9 +21,9 @@ locals {
   budget_start_date = coalesce(var.budget_start_date, "${formatdate("YYYY-MM", timestamp())}-01T00:00:00Z")
 }
 
-# This configuration generates a random string that is appended to resource names to ensure uniqueness, 
-# and then creates an Azure resource group and a Cognitive Services account of kind OpenAI. It conditionally 
-# uses user-supplied names or defaults to the random string, while also appending a user-defined prefix to the 
+# This configuration generates a random string that is appended to resource names to ensure uniqueness,
+# and then creates an Azure resource group and a Cognitive Services account of kind OpenAI. It conditionally
+# uses user-supplied names or defaults to the random string, while also appending a user-defined prefix to the
 # resource group name.
 
 # Create a random string to use in the resource group name

--- a/terragrunt/modules/openai_api_key/variables.tf
+++ b/terragrunt/modules/openai_api_key/variables.tf
@@ -26,10 +26,6 @@ variable "name" {
   description = "The name of the Cognitive Services account. If not specified, a random one will be generated."
 }
 
-variable "subscription_id" {
-  type        = string
-  description = "The subscription ID to create the Azure Cognitive Services account."
-}
 variable "openai_deployments" {
   description = "(Optional) Specifies the deployments of the Azure OpenAI Service"
   type = list(object({
@@ -80,8 +76,8 @@ variable "budget_start_date" {
 
 variable "budget_end_date" {
   description = "End date for the budget alarm (YYYY-MM-DDTHH:MM:SSZ)"
-  type  = string
-  default = "2035-02-01T00:00:00Z"
+  type        = string
+  default     = "2035-02-01T00:00:00Z"
 }
 
 variable "requestor_emails" {

--- a/terragrunt/openai_api_keys.tf
+++ b/terragrunt/openai_api_keys.tf
@@ -1,5 +1,5 @@
 module "valentine_api_key" {
-  source                     = "./modules/openai_api_key"
+  source = "./modules/openai_api_key"
   providers = {
     azurerm = azurerm.sre_tools
   }
@@ -34,7 +34,7 @@ module "valentine_api_key" {
 }
 
 module "ai_answers_api_key" {
-  source                     = "./modules/openai_api_key"
+  source = "./modules/openai_api_key"
   providers = {
     azurerm = azurerm.dto
   }
@@ -157,7 +157,7 @@ module "ai_answers_api_key" {
 
 
 module "dev_ai_api_key" {
-  source                     = "./modules/openai_api_key"
+  source = "./modules/openai_api_key"
   providers = {
     azurerm = azurerm.sre_tools
   }

--- a/terragrunt/openai_api_keys.tf
+++ b/terragrunt/openai_api_keys.tf
@@ -1,6 +1,8 @@
 module "valentine_api_key" {
   source                     = "./modules/openai_api_key"
-  subscription_id            = "204b7832-86f3-4792-8e35-860862258324" # SRE Tools subscription
+  providers = {
+    azurerm = azurerm.sre_tools
+  }
   name                       = "valentine"
   custom_subdomain_name      = "valentine"
   resource_group_name_prefix = "valentine"
@@ -33,7 +35,9 @@ module "valentine_api_key" {
 
 module "ai_answers_api_key" {
   source                     = "./modules/openai_api_key"
-  subscription_id            = "5617b0eb-50cc-4fe6-b57e-021e6ec245f0" # DTO subscription
+  providers = {
+    azurerm = azurerm.dto
+  }
   name                       = "ai-answers"
   custom_subdomain_name      = "ai-answers"
   resource_group_name_prefix = "ai-answers"
@@ -154,7 +158,9 @@ module "ai_answers_api_key" {
 
 module "dev_ai_api_key" {
   source                     = "./modules/openai_api_key"
-  subscription_id            = "204b7832-86f3-4792-8e35-860862258324" # SRE Tools subscription
+  providers = {
+    azurerm = azurerm.sre_tools
+  }
   name                       = "dev-ai-api-key"
   custom_subdomain_name      = "dev-ai-api-key"
   resource_group_name_prefix = "dev-ai-api-key"


### PR DESCRIPTION
# Summary | Résumé

This PR refactor the `openai_api_key` module so there's no providers defined in the modules. This fixes the problem that once the module is created, it cannot be destroyed by deleting the module tf code, because tf needs the provider exist to perform the destroy. 
