### PR TITLE
Chore/ai gateway managed

### DIFF
--- a/terragrunt/ai_gateway.tf
+++ b/terragrunt/ai_gateway.tf
@@ -18,3 +18,10 @@ resource "azuread_application_flexible_federated_identity_credential" "ai_gatewa
   issuer                     = "https://token.actions.githubusercontent.com"
   claims_matching_expression = "claims['sub'] matches 'repo:cds-snc/ai-gateway:*'"
 }
+
+# Contributor role on the target subscription so workflows can create resources
+resource "azurerm_role_assignment" "ai_gateway_contributor_subscription" {
+  scope                = "/subscriptions/c4122b45-f2e3-4873-a7fe-b94c1ad2589f"
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.ai_gateway.object_id
+}

--- a/terragrunt/ai_gateway.tf
+++ b/terragrunt/ai_gateway.tf
@@ -1,0 +1,20 @@
+# AI Gateway — App Registration + Federated Identity for GitHub Actions OIDC
+# Used by cds-snc/ai-gateway workflows to authenticate with Azure via OIDC
+
+resource "azuread_application_registration" "ai_gateway" {
+  display_name = "ai-gateway-github-actions"
+}
+
+resource "azuread_service_principal" "ai_gateway" {
+  client_id = azuread_application_registration.ai_gateway.client_id
+}
+
+# Flexible Federated Identity Credential for the ai-gateway repository
+resource "azuread_application_flexible_federated_identity_credential" "ai_gateway_github_oidc" {
+  application_id             = azuread_application_registration.ai_gateway.id
+  display_name               = "github-actions-ai-gateway"
+  description                = "OIDC for GitHub Actions in cds-snc/ai-gateway"
+  audience                   = "api://AzureADTokenExchange"
+  issuer                     = "https://token.actions.githubusercontent.com"
+  claims_matching_expression = "claims['sub'] matches 'repo:cds-snc/ai-gateway:*'"
+}

--- a/terragrunt/ai_gateway.tf
+++ b/terragrunt/ai_gateway.tf
@@ -21,7 +21,7 @@ resource "azuread_application_flexible_federated_identity_credential" "ai_gatewa
 
 # Contributor role on the target subscription so workflows can create resources
 resource "azurerm_role_assignment" "ai_gateway_contributor_subscription" {
-  scope                = "/subscriptions/c4122b45-f2e3-4873-a7fe-b94c1ad2589f"
+  scope                = "/subscriptions/c4122b45-f2e3-4873-a7fe-b94c1ad2589f" # CDS-AI sub
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.ai_gateway.object_id
 }


### PR DESCRIPTION
Creates a new service principle with federated credentials to be used with the CDS-AI sub and ai-gateway repo.

**Azure AD application and identity setup:**

- Added `azuread_application_registration.ai_gateway` to register a new Azure AD application for GitHub Actions authentication.
- Created `azuread_service_principal.ai_gateway` linked to the application registration.

**Federated identity and permissions:**

- Configured `azuread_application_flexible_federated_identity_credential.ai_gateway_github_oidc` to enable OIDC authentication for the `cds-snc/ai-gateway` repository workflows.
- Assigned the `Contributor` role at the subscription scope to the service principal, allowing workflows to create resources in Azure.