### PR TITLE
Updates gpt-chat to latest, removing deprecated model

### DIFF
--- a/terragrunt/openai_api_keys.tf
+++ b/terragrunt/openai_api_keys.tf
@@ -141,10 +141,10 @@ module "ai_answers_api_key" {
       rai_policy_name = ""
     },
     {
-      name = "openai-gpt51-chat"
+      name = "openai-gpt-chat-latest"
       model = {
-        name    = "gpt-5.1-chat"
-        version = "2025-11-13"
+        name    = "gpt-chat-latest"
+        version = "2026-05-05"
       }
       sku = {
         capacity = 200


### PR DESCRIPTION
Replaces gpt5.1-chat (deprecated) with gpt-chat-latest