### PR TITLE
Fix/ai gateway GitHub token syntax

### DIFF
--- a/terragrunt/ai_gateway.tf
+++ b/terragrunt/ai_gateway.tf
@@ -16,7 +16,7 @@ resource "azuread_application_flexible_federated_identity_credential" "ai_gatewa
   description                = "OIDC for GitHub Actions in cds-snc/ai-gateway"
   audience                   = "api://AzureADTokenExchange"
   issuer                     = "https://token.actions.githubusercontent.com"
-  claims_matching_expression = "claims['repository'] == 'cds-snc/ai-gateway'"
+  claims_matching_expression = "claims['sub'] eq 'repo:cds-snc/ai-gateway:ref:refs/heads/main'"
 }
 
 # Contributor role on the target subscription so workflows can create resources

--- a/terragrunt/ai_gateway.tf
+++ b/terragrunt/ai_gateway.tf
@@ -16,7 +16,7 @@ resource "azuread_application_flexible_federated_identity_credential" "ai_gatewa
   description                = "OIDC for GitHub Actions in cds-snc/ai-gateway"
   audience                   = "api://AzureADTokenExchange"
   issuer                     = "https://token.actions.githubusercontent.com"
-  claims_matching_expression = "claims['sub'] matches 'repo:cds-snc/ai-gateway:*'"
+  claims_matching_expression = "claims['repository'] == 'cds-snc/ai-gateway'"
 }
 
 # Contributor role on the target subscription so workflows can create resources


### PR DESCRIPTION
This pull request updates the OIDC claims matching expression for the Azure AD application federated identity credential in the `ai_gateway.tf` configuration. The change restricts authentication to only allow tokens from the `main` branch, increasing deployment security.

Security and access control:

* Updated the `claims_matching_expression` in the `azuread_application_flexible_federated_identity_credential` resource to only match tokens from the `main` branch (`repo:cds-snc/ai-gateway:ref:refs/heads/main`), rather than any ref in the repository.