### PR TITLE
feat: add OIDC for AI Gateway PR

### DIFF
--- a/terragrunt/ai_gateway.tf
+++ b/terragrunt/ai_gateway.tf
@@ -19,6 +19,16 @@ resource "azuread_application_flexible_federated_identity_credential" "ai_gatewa
   claims_matching_expression = "claims['sub'] eq 'repo:cds-snc/ai-gateway:ref:refs/heads/main'"
 }
 
+# Allow OIDC tokens from pull_request workflow context
+resource "azuread_application_flexible_federated_identity_credential" "ai_gateway_github_oidc_pull_request" {
+  application_id             = azuread_application_registration.ai_gateway.id
+  display_name               = "github-actions-ai-gateway-pr"
+  description                = "OIDC for GitHub Actions pull_request events in cds-snc/ai-gateway"
+  audience                   = "api://AzureADTokenExchange"
+  issuer                     = "https://token.actions.githubusercontent.com"
+  claims_matching_expression = "claims['sub'] eq 'repo:cds-snc/ai-gateway:pull_request'"
+}
+
 # Contributor role on the target subscription so workflows can create resources
 resource "azurerm_role_assignment" "ai_gateway_contributor_subscription" {
   scope                = "/subscriptions/c4122b45-f2e3-4873-a7fe-b94c1ad2589f" # CDS-AI sub


### PR DESCRIPTION
Adds the OIDC Identity that can be used by the AI Gateway PRs.

Should allow me to progress beyond this issue: https://github.com/cds-snc/ai-gateway/actions/runs/30317731112/job/90146864611?pr=44