### PR TITLE
fix: redo with older OIDC credential

### DIFF
--- a/terragrunt/ai_gateway.tf
+++ b/terragrunt/ai_gateway.tf
@@ -9,24 +9,24 @@ resource "azuread_service_principal" "ai_gateway" {
   client_id = azuread_application_registration.ai_gateway.client_id
 }
 
-# Flexible Federated Identity Credential for the ai-gateway repository
-resource "azuread_application_flexible_federated_identity_credential" "ai_gateway_github_oidc" {
-  application_id             = azuread_application_registration.ai_gateway.id
-  display_name               = "github-actions-ai-gateway"
-  description                = "OIDC for GitHub Actions in cds-snc/ai-gateway"
-  audience                   = "api://AzureADTokenExchange"
-  issuer                     = "https://token.actions.githubusercontent.com"
-  claims_matching_expression = "claims['sub'] eq 'repo:cds-snc/ai-gateway:ref:refs/heads/main'"
+# Federated Identity Credential for main branch workflow tokens
+resource "azuread_application_federated_identity_credential" "ai_gateway_github_oidc_main" {
+  application_id = azuread_application_registration.ai_gateway.id
+  display_name   = "github-actions-ai-gateway-main"
+  description    = "OIDC for GitHub Actions main branch in cds-snc/ai-gateway"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:cds-snc/ai-gateway:ref:refs/heads/main"
 }
 
-# Allow OIDC tokens from pull_request workflow context
-resource "azuread_application_flexible_federated_identity_credential" "ai_gateway_github_oidc_pull_request" {
-  application_id             = azuread_application_registration.ai_gateway.id
-  display_name               = "github-actions-ai-gateway-pr"
-  description                = "OIDC for GitHub Actions pull_request events in cds-snc/ai-gateway"
-  audience                   = "api://AzureADTokenExchange"
-  issuer                     = "https://token.actions.githubusercontent.com"
-  claims_matching_expression = "claims['sub'] eq 'repo:cds-snc/ai-gateway:pull_request'"
+# Federated Identity Credential for pull_request workflow tokens
+resource "azuread_application_federated_identity_credential" "ai_gateway_github_oidc_pull_request" {
+  application_id = azuread_application_registration.ai_gateway.id
+  display_name   = "github-actions-ai-gateway-pr"
+  description    = "OIDC for GitHub Actions pull_request events in cds-snc/ai-gateway"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:cds-snc/ai-gateway:pull_request"
 }
 
 # Contributor role on the target subscription so workflows can create resources


### PR DESCRIPTION
Because of an issue with applying we are going to try this without flexible identity credentials. 

Error logs for the apply: https://github.com/cds-snc/cds-azure-resources/actions/runs/30362117821/job/90284136999

I have no guarantee this will work. 