### PR TITLE
feat: add the AWS Cognito managed identity for the Sentinel forwarder

### DIFF
--- a/terragrunt/sentinel_forwarder_v2.tf
+++ b/terragrunt/sentinel_forwarder_v2.tf
@@ -29,3 +29,78 @@ resource "azurerm_role_assignment" "sentinel_forwarder_v2_metrics_publisher" {
   role_definition_name = "Monitoring Metrics Publisher"
   principal_id         = azuread_service_principal.sentinel_forwarder_v2.object_id
 }
+
+# ---------------------------------------------------------------------------
+# Sentinel Forwarder v2 — User-Assigned Managed Identity for AWS Lambda,
+# federated from Amazon Cognito.
+#
+# Used by the AWS forwarders (cds-snc/aws-sentinel-connector-layer) to reach the
+# Logs Ingestion API with no stored secret. A Lambda calls
+# cognito-identity:GetOpenIdTokenForDeveloperIdentity with only its IAM role,
+# then presents the resulting OIDC JWT to Entra as a client_assertion to get a
+# token for this identity.
+#
+# A managed identity rather than an app registration because a managed identity
+# cannot hold a client secret or certificate at all, so "no stored secret" is a
+# property of the object rather than a policy someone has to keep enforcing.
+# ---------------------------------------------------------------------------
+
+resource "azurerm_user_assigned_identity" "sentinel_forwarder_v2_aws_cognito" {
+  name                = "sentinel-forwarder-v2-aws-cognito"
+  resource_group_name = data.azurerm_resource_group.cds_snc_mgmt.name
+  location            = var.primary_location
+  tags                = local.common_tags
+}
+
+# Scoped to the whole resource group so one identity covers every DCR in
+# cds-snc-mgmt, current and future, without a grant per forwarder.
+#
+# Two consequences to be aware of, both accepted deliberately:
+#   - reach: this covers all DCRs in the group, not only the AWS ones;
+#   - permanence: cds-snc-mgmt carries a CanNotDelete lock, which blocks
+#     deleting role assignments as well as resources (`az role assignment
+#     delete` returns ScopeLocked), so this grant cannot be removed while the
+#     lock stands.
+resource "azurerm_role_assignment" "sentinel_forwarder_v2_aws_cognito_metrics_publisher" {
+  scope                = data.azurerm_resource_group.cds_snc_mgmt.id
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = azurerm_user_assigned_identity.sentinel_forwarder_v2_aws_cognito.principal_id
+}
+
+# One credential per Cognito identity permitted to act as this managed identity.
+#
+# The subject is the Cognito IdentityId, which does not exist until the pool
+# mints one — so the order is: create the pool in the Lambda's own AWS account,
+# let it mint an identity, then add it here. Identity pools have no resource
+# policy, so a pool cannot be called cross-account; each AWS account running a
+# forwarder needs its own pool and therefore its own entry.
+variable "sentinel_forwarder_v2_aws_cognito_identities" {
+  description = "Cognito identities allowed to obtain a token as the AWS forwarder managed identity. Key is a short label (typically the AWS account or forwarder name); identity_pool_id becomes the credential audience and identity_id its subject."
+  type = map(object({
+    identity_pool_id = string
+    identity_id      = string
+  }))
+  default = {}
+}
+
+resource "azurerm_federated_identity_credential" "sentinel_forwarder_v2_aws_cognito" {
+  for_each = var.sentinel_forwarder_v2_aws_cognito_identities
+
+  name                      = "aws-cognito-${each.key}"
+  user_assigned_identity_id = azurerm_user_assigned_identity.sentinel_forwarder_v2_aws_cognito.id
+  audience                  = [each.value.identity_pool_id]
+  issuer                    = "https://cognito-identity.amazonaws.com"
+  subject                   = each.value.identity_id
+}
+
+# The Lambda needs the client id as ARM_CLIENT_ID; it is also the developer user
+# identifier passed to Cognito, which keeps the IdentityId mapping deterministic.
+output "sentinel_forwarder_v2_aws_cognito_client_id" {
+  description = "Client id of the AWS forwarder managed identity — the Lambda's ARM_CLIENT_ID."
+  value       = azurerm_user_assigned_identity.sentinel_forwarder_v2_aws_cognito.client_id
+}
+
+output "sentinel_forwarder_v2_aws_cognito_principal_id" {
+  description = "Object id of the AWS forwarder managed identity, for role assignments outside this module."
+  value       = azurerm_user_assigned_identity.sentinel_forwarder_v2_aws_cognito.principal_id
+}


### PR DESCRIPTION
## Summary

This PR adds a user-assigned managed identity that the AWS forwarder Lambdas federate into from Amazon Cognito, so they reach the Logs Ingestion API with no stored secret.

### Why a managed identity rather than an app registration

The token exchange is identical either way. The difference is that **a managed identity cannot hold a client secret or certificate at all**, so "no stored secret" is a property of the object rather than a policy someone has to keep enforcing. It is also an ARM resource, so Terraform manages it with resource-group RBAC instead of directory roles.

### Role assignment scope

Monitoring Metrics Publisher is granted at **`cds-snc-mgmt` resource group scope**, so one identity covers every DCR in the group — currently 31 — without a grant per forwarder. Two consequences, both accepted deliberately and recorded in comments on the resource:

- **Reach**: it covers all DCRs in the group, not only the AWS ones, and any DCR created there later.
- **Permanence**: `cds-snc-mgmt` carries a `CanNotDelete` lock, which blocks deleting role assignments as well as resources (`az role assignment delete` returns `ScopeLocked`), so this grant cannot be removed while the lock stands.

### Federated credentials

A `for_each` over `var.sentinel_forwarder_v2_aws_cognito_identities`, empty by default so this plans clean today. The subject is the Cognito `IdentityId`, which does not exist until a pool mints one, and identity pools have no resource policy — so each AWS account running a forwarder needs its own pool and its own entry here.

## Test instructions

1. `cd terragrunt && terragrunt plan`
2. Expect three resources added — the identity, the role assignment, and no federated credentials, since the map defaults to empty. Nothing else in the plan should move.
3. After apply, confirm the grant landed: `az role assignment list --assignee $(terraform output -raw sentinel_forwarder_v2_aws_cognito_principal_id)` should show Monitoring Metrics Publisher at the `cds-snc-mgmt` scope. Expect a few minutes before it takes effect on the data plane.
4. To add a forwarder later, create the Cognito pool in that Lambda's own AWS account, let it mint an `IdentityId`, then add `{ identity_pool_id, identity_id }` to the map.